### PR TITLE
Change fluid color to match Botania

### DIFF
--- a/src/main/java/ms55/manaliquidizer/common/fluid/ModFluids.java
+++ b/src/main/java/ms55/manaliquidizer/common/fluid/ModFluids.java
@@ -28,7 +28,7 @@ public class ModFluids {
 
 	private static ForgeFlowingFluid.Properties makeProperties() {
         return new ForgeFlowingFluid.Properties(MANA_FLUID, MANA_FLUID_FLOWING,
-        	FluidAttributes.builder(FLUID_STILL, FLUID_FLOWING).overlay(FLUID_OVERLAY).color(0xFF1080FF))
+        	FluidAttributes.builder(FLUID_STILL, FLUID_FLOWING).overlay(FLUID_OVERLAY).color(0xFF4BD5F2))
             .bucket(MANA_FLUID_BUCKET).block(MANA_FLUID_BLOCK);
     }
 


### PR DESCRIPTION
I went ahead and changed the current color from 0xFF1080FF to 0xFF4BD5F2 so it more closely resembles the default mana color in mana pools. The dark blue water-like texture was dropped in favor of a lighter blue.

Old color:
![image](https://user-images.githubusercontent.com/70091260/103598146-8e43b000-4f0a-11eb-9992-a01fa6ddb8da.png)

New color:
![image](https://user-images.githubusercontent.com/70091260/103598164-9ac80880-4f0a-11eb-87f2-b6b43831b4cc.png)

For reference:
![image](https://user-images.githubusercontent.com/70091260/103598483-630d9080-4f0b-11eb-8648-797b78a94643.png)


Please test this first if you do decide to accept the change. I don't know how to make Minecraft mods so I just changed this value via the Github web interface, and haven't tested it locally or anything.